### PR TITLE
🧹 Clean up redundant type assertions in tests

### DIFF
--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -91,9 +91,5 @@ def test_successful_search(client, mocker):
 
         # Check the structure of the first result
         first_result = validated_data.results[0]
-        assert isinstance(first_result.title, str)
-        assert first_result.title is not None and first_result.title != ""
-        assert isinstance(first_result.url, str)
+        assert first_result.title != ""
         assert first_result.url.startswith("http")
-        # Content can sometimes be None, so we don't assert its type strictly
-        assert isinstance(first_result.engine, str)


### PR DESCRIPTION
Removed redundant `isinstance` and `is not None` assertions in `tests/integration/test_search.py`. These assertions were unnecessary because Pydantic's `model_validate` already guarantees the types and existence of these fields. Also cleaned up a dangling comment.

---
*PR created automatically by Jules for task [16345105546112938022](https://jules.google.com/task/16345105546112938022) started by @chottokun*