### PR TITLE
🧪 Add edge case tests for PII detection settings in PiiService

### DIFF
--- a/tests/unit/test_pii_service.py
+++ b/tests/unit/test_pii_service.py
@@ -70,3 +70,49 @@ def test_mask_results(pii_service):
     masked = pii_service.mask_results(mock_results)
     assert masked.results[0].title == "My IP is [REDACTED_IP]"
     assert masked.results[0].content == "API Key [REDACTED_KEY] works"
+
+def test_inspect_query_pii_detection_disabled(pii_service, mocker):
+    mocker.patch("src.services.pii_service.settings.PII_DETECTION_ENABLED", False)
+    query = "My email is test@example.com"
+    assert pii_service.inspect_query(query) == query
+
+def test_inspect_query_pii_block_level_off(pii_service, mocker):
+    mocker.patch("src.services.pii_service.settings.PII_BLOCK_LEVEL", "off")
+    query = "My email is test@example.com"
+    assert pii_service.inspect_query(query) == query
+
+def test_mask_results_pii_detection_disabled(pii_service, mocker):
+    mocker.patch("src.services.pii_service.settings.PII_DETECTION_ENABLED", False)
+    mock_results = ResultSet(
+        query="test",
+        number_of_results=1,
+        results=[
+            SearchResult(
+                title="My IP is 192.168.1.1",
+                url="http://example.com",
+                content="API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works",
+                engine="google"
+            )
+        ]
+    )
+    masked = pii_service.mask_results(mock_results)
+    assert masked.results[0].title == "My IP is 192.168.1.1"
+    assert masked.results[0].content == "API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works"
+
+def test_mask_results_pii_mask_response_disabled(pii_service, mocker):
+    mocker.patch("src.services.pii_service.settings.PII_MASK_RESPONSE", False)
+    mock_results = ResultSet(
+        query="test",
+        number_of_results=1,
+        results=[
+            SearchResult(
+                title="My IP is 192.168.1.1",
+                url="http://example.com",
+                content="API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works",
+                engine="google"
+            )
+        ]
+    )
+    masked = pii_service.mask_results(mock_results)
+    assert masked.results[0].title == "My IP is 192.168.1.1"
+    assert masked.results[0].content == "API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works"


### PR DESCRIPTION
This PR improves the test coverage for `PiiService` by addressing missing edge cases related to PII detection settings.

🎯 **What:** The testing gap addressed
- Added tests for `inspect_query` when `PII_DETECTION_ENABLED` is `False`.
- Added tests for `inspect_query` when `PII_BLOCK_LEVEL` is set to `"off"`.
- Added tests for `mask_results` when `PII_DETECTION_ENABLED` is `False`.
- Added tests for `mask_results` when `PII_MASK_RESPONSE` is `False`.

📊 **Coverage:** What scenarios are now tested
- Bypassing of query inspection when PII detection is disabled.
- Bypassing of query inspection when block level is "off".
- Skipping of result masking when PII detection or response masking is disabled.

✨ **Result:** The improvement in test coverage
- Increased reliability of the `PiiService` by ensuring configuration flags are respected.
- Guaranteed that the service does not unintentionally block or mask data when explicitly disabled.

---
*PR created automatically by Jules for task [2020633228592806650](https://jules.google.com/task/2020633228592806650) started by @chottokun*