### PR TITLE
🧪 [testing improvement] Add edge case tests for search method parameters

### DIFF
--- a/tests/unit/test_searxng_service.py
+++ b/tests/unit/test_searxng_service.py
@@ -1,0 +1,85 @@
+import pytest
+import httpx
+from src.services.searxng_service import SearxngService, SearxngUnavailableError
+
+@pytest.fixture
+def searxng_service():
+    return SearxngService()
+
+@pytest.mark.anyio
+async def test_search_params_only_q(searxng_service, mocker):
+    # Mock response
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query": "test", "results": []}
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_get = mocker.patch.object(httpx.AsyncClient, "get", return_value=mock_response)
+
+    await searxng_service.search(q="test", categories=None, time_range=None)
+
+    args, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"q": "test", "format": "json"}
+
+@pytest.mark.anyio
+async def test_search_params_with_categories(searxng_service, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query": "test", "results": []}
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_get = mocker.patch.object(httpx.AsyncClient, "get", return_value=mock_response)
+
+    await searxng_service.search(q="test", categories="news,files", time_range=None)
+
+    args, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"q": "test", "format": "json", "categories": "news,files"}
+
+@pytest.mark.anyio
+async def test_search_params_with_time_range(searxng_service, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query": "test", "results": []}
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_get = mocker.patch.object(httpx.AsyncClient, "get", return_value=mock_response)
+
+    await searxng_service.search(q="test", categories=None, time_range="day")
+
+    args, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"q": "test", "format": "json", "time_range": "day"}
+
+@pytest.mark.anyio
+async def test_search_params_all(searxng_service, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"query": "test", "results": []}
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_get = mocker.patch.object(httpx.AsyncClient, "get", return_value=mock_response)
+
+    await searxng_service.search(q="test", categories="news", time_range="month")
+
+    args, kwargs = mock_get.call_args
+    assert kwargs["params"] == {
+        "q": "test",
+        "format": "json",
+        "categories": "news",
+        "time_range": "month"
+    }
+
+@pytest.mark.anyio
+async def test_search_raises_unavailable_on_request_error(searxng_service, mocker):
+    mocker.patch.object(httpx.AsyncClient, "get", side_effect=httpx.RequestError("error"))
+
+    with pytest.raises(SearxngUnavailableError):
+        await searxng_service.search(q="test", categories=None, time_range=None)
+
+@pytest.mark.anyio
+async def test_search_raises_unavailable_on_http_error(searxng_service, mocker):
+    mock_response = mocker.Mock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=mocker.Mock(), response=mocker.Mock())
+    mocker.patch.object(httpx.AsyncClient, "get", return_value=mock_response)
+
+    with pytest.raises(SearxngUnavailableError):
+        await searxng_service.search(q="test", categories=None, time_range=None)


### PR DESCRIPTION
This PR addresses the missing edge case tests for the `SearxngService.search` method parameters. 

### 🎯 What:
Added comprehensive unit tests for the `SearxngService` class, specifically focusing on the `search` method's parameter construction and its error handling logic.

### 📊 Coverage:
The following scenarios are now covered by unit tests:
- **Parameter Validation:**
  - Search with only the query `q`.
  - Search with `q` and `categories`.
  - Search with `q` and `time_range`.
  - Search with all parameters combined.
- **Error Handling:**
  - Proper translation of `httpx.RequestError` to `SearxngUnavailableError`.
  - Proper translation of `httpx.HTTPStatusError` (via `raise_for_status`) to `SearxngUnavailableError`.

### ✨ Result:
- Improved test coverage for core service logic.
- Increased reliability of parameter passing to the SearXNG API.
- Verified robust error handling and exception translation.
- All 24 tests in the suite (including contract and integration tests) are passing.

---
*PR created automatically by Jules for task [13183027483355591409](https://jules.google.com/task/13183027483355591409) started by @chottokun*