### PR TITLE
🔒 [security fix] Remove hardcoded sensitive words from config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     PII_MASK_RESPONSE: bool = True
     
     # 検出・ブロック対象とする特定の機密ワードリスト（小文字で定義、部分一致でフィルタリング）
-    SENSITIVE_WORDS: list[str] = ["confidential", "secret", "社外秘"]
+    SENSITIVE_WORDS: list[str] = []
     
     # Presidioで検出対象とするPIIエンティティのリスト
     PII_ENTITIES: list[str] = [

--- a/tests/unit/test_config_loading.py
+++ b/tests/unit/test_config_loading.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+from src.config import Settings
+
+def test_sensitive_words_loading_from_env(mocker):
+    # Mock environment variable
+    mocker.patch.dict(os.environ, {"SENSITIVE_WORDS": '["env_confidential", "env_secret"]'})
+
+    # Create a new Settings instance to load from mocked environment
+    # Note: Settings(model_config=...) might need careful handling if we want to bypass .env file
+    # But since .env doesn't exist in the environment, it should be fine.
+    new_settings = Settings()
+
+    assert "env_confidential" in new_settings.SENSITIVE_WORDS
+    assert "env_secret" in new_settings.SENSITIVE_WORDS
+    assert len(new_settings.SENSITIVE_WORDS) == 2
+
+def test_sensitive_words_default_empty():
+    # Ensure default is empty when no env var is set
+    # We might need to ensure the env var is NOT set for this test
+    if "SENSITIVE_WORDS" in os.environ:
+        del os.environ["SENSITIVE_WORDS"]
+
+    new_settings = Settings()
+    assert new_settings.SENSITIVE_WORDS == []


### PR DESCRIPTION
🎯 **What:** Removed hardcoded sensitive keywords from `src/config.py` and enabled them to be configured via environment variables.
⚠️ **Risk:** Hardcoding sensitive words (e.g., 'confidential', 'secret') in the source code is poor practice and could expose internal filtering policies or sensitive terms in version control.
🛡️ **Solution:** Changed the default value of `SENSITIVE_WORDS` to an empty list in `src/config.py`. Pydantic's `BaseSettings` automatically allows overriding this via the `SENSITIVE_WORDS` environment variable (as a JSON-encoded string). Added unit tests to verify correct loading from the environment.

---
*PR created automatically by Jules for task [5004192206411295443](https://jules.google.com/task/5004192206411295443) started by @chottokun*