### PR TITLE
🧪 [testing improvement] Add edge case tests for disabled PII detection

### DIFF
--- a/tests/unit/test_pii_service.py
+++ b/tests/unit/test_pii_service.py
@@ -70,3 +70,57 @@ def test_mask_results(pii_service):
     masked = pii_service.mask_results(mock_results)
     assert masked.results[0].title == "My IP is [REDACTED_IP]"
     assert masked.results[0].content == "API Key [REDACTED_KEY] works"
+
+def test_inspect_query_disabled(pii_service, mocker):
+    """PII検出が無効な場合、クエリが変更されないことを検証します。"""
+    mocker.patch("src.services.pii_service.settings.PII_DETECTION_ENABLED", False)
+    query = "Contact john.doe@example.com"
+    assert pii_service.inspect_query(query) == query
+
+def test_inspect_query_off_level(pii_service, mocker):
+    """PIIブロックレベルが'off'の場合、クエリが変更されないことを検証します。"""
+    mocker.patch("src.services.pii_service.settings.PII_DETECTION_ENABLED", True)
+    mocker.patch("src.services.pii_service.settings.PII_BLOCK_LEVEL", "off")
+    query = "Contact john.doe@example.com"
+    assert pii_service.inspect_query(query) == query
+
+def test_mask_results_disabled(pii_service, mocker):
+    """PII検出が無効な場合、検索結果がマスキングされないことを検証します。"""
+    mocker.patch("src.services.pii_service.settings.PII_DETECTION_ENABLED", False)
+    mock_results = ResultSet(
+        query="test",
+        number_of_results=1,
+        results=[
+            SearchResult(
+                title="My email is john.doe@example.com",
+                url="http://example.com",
+                content="Call me at 090-1234-5678",
+                engine="google"
+            )
+        ]
+    )
+
+    masked = pii_service.mask_results(mock_results)
+    assert masked.results[0].title == "My email is john.doe@example.com"
+    assert masked.results[0].content == "Call me at 090-1234-5678"
+
+def test_mask_results_off_masking(pii_service, mocker):
+    """レスポンスのマスキングが設定でオフの場合、検索結果がマスキングされないことを検証します。"""
+    mocker.patch("src.services.pii_service.settings.PII_DETECTION_ENABLED", True)
+    mocker.patch("src.services.pii_service.settings.PII_MASK_RESPONSE", False)
+    mock_results = ResultSet(
+        query="test",
+        number_of_results=1,
+        results=[
+            SearchResult(
+                title="My email is john.doe@example.com",
+                url="http://example.com",
+                content="Call me at 090-1234-5678",
+                engine="google"
+            )
+        ]
+    )
+
+    masked = pii_service.mask_results(mock_results)
+    assert masked.results[0].title == "My email is john.doe@example.com"
+    assert masked.results[0].content == "Call me at 090-1234-5678"


### PR DESCRIPTION
This PR adds unit tests to cover edge cases in `PiiService` where PII detection or masking is disabled via settings.

🎯 **What:** The testing gap addressed
- `PiiService.inspect_query` logic when `PII_DETECTION_ENABLED` is `False` or `PII_BLOCK_LEVEL` is `"off"`.
- `PiiService.mask_results` logic when `PII_DETECTION_ENABLED` is `False` or `PII_MASK_RESPONSE` is `False`.

📊 **Coverage:** What scenarios are now tested
- Query inspection with PII detection globally disabled.
- Query inspection with block level set to 'off'.
- Response masking with PII detection globally disabled.
- Response masking with response masking specifically disabled.

✨ **Result:** The improvement in test coverage
- Increased reliability by ensuring that queries and search results remain untouched when security features are turned off, preventing unintended data modification or search failures when users want to bypass PII checks.

---
*PR created automatically by Jules for task [4456723192620429756](https://jules.google.com/task/4456723192620429756) started by @chottokun*