### PR TITLE
🧹 remove redundant 'isinstance' and assertions in tests

### DIFF
--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -91,9 +91,5 @@ def test_successful_search(client, mocker):
 
         # Check the structure of the first result
         first_result = validated_data.results[0]
-        assert isinstance(first_result.title, str)
-        assert first_result.title is not None and first_result.title != ""
-        assert isinstance(first_result.url, str)
+        assert first_result.title != ""
         assert first_result.url.startswith("http")
-        # Content can sometimes be None, so we don't assert its type strictly
-        assert isinstance(first_result.engine, str)


### PR DESCRIPTION
The code health improvement addressed redundant type-checking and null-checks in integration tests. Since Pydantic models validate data upon instantiation, explicit `isinstance` and `is not None` assertions for required fields are redundant. Removing them simplifies the test code and improves readability without sacrificing safety.

🎯 **What:** Removed `isinstance(..., str)` and `... is not None` checks in `tests/integration/test_search.py`.
💡 **Why:** Pydantic validation already ensures these types and presence, making the assertions boilerplate.
✅ **Verification:** All tests passed (18 tests, 4 warnings unrelated to these changes).
✨ **Result:** Cleaner and more maintainable integration tests.

---
*PR created automatically by Jules for task [14897713787740282086](https://jules.google.com/task/14897713787740282086) started by @chottokun*