### PR TITLE
🧹 remove unused List import in pii_service.py

### DIFF
--- a/src/services/pii_service.py
+++ b/src/services/pii_service.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 from presidio_analyzer import AnalyzerEngine, PatternRecognizer, Pattern
 from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine
@@ -82,7 +81,7 @@ class PiiService:
                 )
                 self.analyzer.registry.add_recognizer(sensitive_recognizer)
 
-    def _analyze_multilingual(self, text: str, entities: List[str]) -> list:
+    def _analyze_multilingual(self, text: str, entities: list[str]) -> list:
         """
         英語（en）と日本語（ja）の両方のNLPモデル・認識器で解析を行い、結果を統合します。
         スパン（位置）が重複する場合、より高スコアまたは詳細なエンティティを優先してマージします。


### PR DESCRIPTION
The `List` import in `src/services/pii_service.py` was identified as unused by static analysis. While it was actually used in one type hint, I have modernized that type hint to use the built-in `list` type (as the project uses Python 3.12) and removed the now-redundant import.

I verified the fix by:
1. Reading the file content to ensure no required imports (like `settings` or `NlpEngineProvider`) were accidentally removed.
2. Running the full test suite (unit, integration, and contract tests), all of which passed.
3. Confirming the Python version is 3.12, supporting the use of built-in generics in type hints.

---
*PR created automatically by Jules for task [8647164363145764445](https://jules.google.com/task/8647164363145764445) started by @chottokun*