### PR TITLE
🧪 [testing improvement] Add edge cases for disabled PII detection and masking

### DIFF
--- a/tests/unit/test_pii_service.py
+++ b/tests/unit/test_pii_service.py
@@ -70,3 +70,50 @@ def test_mask_results(pii_service):
     masked = pii_service.mask_results(mock_results)
     assert masked.results[0].title == "My IP is [REDACTED_IP]"
     assert masked.results[0].content == "API Key [REDACTED_KEY] works"
+
+def test_inspect_query_disabled(pii_service, mocker):
+    """PII検出が無効な場合にクエリがそのまま返されることをテストします。"""
+    from src.services.pii_service import settings
+    query = "My email is john@example.com"
+
+    # PII_DETECTION_ENABLED が False の場合
+    mocker.patch.object(settings, "PII_DETECTION_ENABLED", False)
+    assert pii_service.inspect_query(query) == query
+
+    # PII_BLOCK_LEVEL が 'off' の場合
+    mocker.patch.object(settings, "PII_DETECTION_ENABLED", True)
+    mocker.patch.object(settings, "PII_BLOCK_LEVEL", "off")
+    assert pii_service.inspect_query(query) == query
+
+def test_mask_results_disabled(pii_service, mocker):
+    """PIIマスキングが無効な場合に結果がそのまま返されることをテストします。"""
+    from src.services.pii_service import settings
+
+    def get_mock_results():
+        return ResultSet(
+            query="test",
+            number_of_results=1,
+            results=[
+                SearchResult(
+                    title="My IP is 192.168.1.1",
+                    url="http://example.com",
+                    content="API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works",
+                    engine="google"
+                )
+            ]
+        )
+
+    # Case 1: PII_DETECTION_ENABLED が False の場合
+    mocker.patch.object(settings, "PII_DETECTION_ENABLED", False)
+    mock_results = get_mock_results()
+    masked = pii_service.mask_results(mock_results)
+    assert masked.results[0].title == "My IP is 192.168.1.1"
+    assert masked.results[0].content == "API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works"
+
+    # Case 2: PII_MASK_RESPONSE が False の場合
+    mocker.patch.object(settings, "PII_DETECTION_ENABLED", True)
+    mocker.patch.object(settings, "PII_MASK_RESPONSE", False)
+    mock_results = get_mock_results()
+    masked = pii_service.mask_results(mock_results)
+    assert masked.results[0].title == "My IP is 192.168.1.1"
+    assert masked.results[0].content == "API Key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLM works"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Added missing unit tests for `PiiService.inspect_query` and `PiiService.mask_results` when PII detection or masking is disabled via configuration.

📊 **Coverage:** What scenarios are now tested
- `inspect_query` returns the original query when `PII_DETECTION_ENABLED` is `False`.
- `inspect_query` returns the original query when `PII_BLOCK_LEVEL` is set to `"off"`.
- `mask_results` returns the original `ResultSet` when `PII_DETECTION_ENABLED` is `False`.
- `mask_results` returns the original `ResultSet` when `PII_MASK_RESPONSE` is `False`.

✨ **Result:** The improvement in test coverage
- Ensures that the privacy service correctly honors "off" switches without accidentally modifying queries or search results.
- Strengthened the safety net for configuration-driven behavior in `PiiService`.

---
*PR created automatically by Jules for task [17632741060822717134](https://jules.google.com/task/17632741060822717134) started by @chottokun*