### PR TITLE
🔒 [security fix] Remove hardcoded secret_key from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ curl -i http://127.0.0.1:8000/mcp
 ```
 It should return a `406 Not Acceptable` (`"Client must accept text/event-stream"`), indicating that the server is up and listening.
 
+> **Important Security Note:** You must set a secure `SEARXNG_SECRET` environment variable for SearXNG to function properly and securely. You can generate one using:
+> ```bash
+> openssl rand -hex 32
+> ```
+> Then, add it to your `.env` file or export it:
+> ```bash
+> export SEARXNG_SECRET=your_generated_secret_here
+> ```
+
 #### 2. Running Locally
 
 Install dependencies:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - SEARXNG_BASE_URL=http://localhost:8080/
       - INSTANCE_NAME="mcp-searxng-instance"
       - SEARXNG_VALKEY_URL=valkey://valkey:6379/0
+      - SEARXNG_SECRET=${SEARXNG_SECRET}
     cap_drop:
       - ALL
     cap_add:

--- a/searxng_config/settings.yml.example
+++ b/searxng_config/settings.yml.example
@@ -2,7 +2,9 @@ use_default_settings: true
 
 server:
   base_url: "http://localhost:8080/"
-  secret_key: "a_very_secret_key_that_you_should_change"
+  # The secret_key is used for cryptography purpose.
+  # It should be set via the SEARXNG_SECRET environment variable for security.
+  secret_key: ""
   bind_address: "0.0.0.0"
   port: 8080
 


### PR DESCRIPTION
This pull request addresses a security vulnerability where a hardcoded secret key was present in the SearXNG configuration.

### 🎯 What: 
Removed the hardcoded dummy secret key from the configuration and moved its management to environment variables.

### ⚠️ Risk:
Committing hardcoded secrets to version control can lead to security breaches if the repository is compromised or shared. It also encourages insecure deployment practices.

### 🛡️ Solution:
1.  Modified `searxng_config/settings.yml.example` to remove the hardcoded dummy key and added a comment directing users to use the `SEARXNG_SECRET` environment variable.
2.  Updated `docker-compose.yml` to pass the `SEARXNG_SECRET` environment variable to the `searxng` service.
3.  Updated `README.md` with instructions on how to generate a secure 32-byte hex secret and set it as an environment variable.

All existing tests pass, and the application now follows security best practices for secret management.

---
*PR created automatically by Jules for task [7776585881521110025](https://jules.google.com/task/7776585881521110025) started by @chottokun*