### PR TITLE
🔒 Fix hardcoded secret key in SearXNG configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - SEARXNG_BASE_URL=http://localhost:8080/
       - INSTANCE_NAME="mcp-searxng-instance"
       - SEARXNG_VALKEY_URL=valkey://valkey:6379/0
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-change_me_to_a_secure_random_string}
     cap_drop:
       - ALL
     cap_add:

--- a/searxng_config/settings.yml.example
+++ b/searxng_config/settings.yml.example
@@ -2,7 +2,7 @@ use_default_settings: true
 
 server:
   base_url: "http://localhost:8080/"
-  secret_key: "a_very_secret_key_that_you_should_change"
+  # secret_key is managed via SEARXNG_SECRET environment variable
   bind_address: "0.0.0.0"
   port: 8080
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Hardcoded `secret_key` in `searxng_config/settings.yml` and its example file.

### ⚠️ Risk: The potential impact if left unfixed
If a hardcoded secret key is committed to version control, it can be exploited to compromise the security of the SearXNG instance (e.g., forging session cookies, bypassing security measures).

### 🛡️ Solution: How the fix addresses the vulnerability
The hardcoded secret was removed from the YAML configuration files. Instead, the system now relies on the `SEARXNG_SECRET` environment variable, which is passed via `docker-compose.yml`. This allows the secret to be managed securely (e.g., via a `.env` file that is not committed to git) while maintaining a functional default for development environments.

---
*PR created automatically by Jules for task [9980362367141771144](https://jules.google.com/task/9980362367141771144) started by @chottokun*